### PR TITLE
Modify access log, correcting response size element (was duplicated) …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ repositories {
 
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.0'
-    compile 'org.slf4j:slf4j-log4j12:1.7.0'
     compile 'com.google.code.gson:gson:2.4'
     compile 'io.reactivex:rxjava:1.0.14'
     compile "io.reactivex:rxnetty:0.4.9"

--- a/src/main/java/com/scmspain/karyon/accesslog/AccessLog.java
+++ b/src/main/java/com/scmspain/karyon/accesslog/AccessLog.java
@@ -10,6 +10,7 @@ public class AccessLog {
   private RequestBag request;
   private ResponseBag response;
   private ClientBag client;
+  private TraceBag traceBag;
 
   public AccessLog(String httpVersion, String method, String uri) {
     this.request = new RequestBag(httpVersion, method, uri);
@@ -23,10 +24,13 @@ public class AccessLog {
       String uri,
       String clientIp,
       String userAgent,
-      String referer
+      String referer,
+      String zipkinParentId,
+      String zipkinTraceId
   ) {
     this(httpVersion, method, uri);
     this.client = new ClientBag(clientIp, userAgent, referer);
+    this.traceBag = new TraceBag(zipkinParentId, zipkinTraceId);
   }
 
   public AccessLog(
@@ -38,9 +42,11 @@ public class AccessLog {
           String referer,
           Integer statusCode,
           Long timeTaken,
-          Long responseSize
+          Long responseSize,
+          String zipkinParentId,
+          String zipkinTraceId
   ) {
-    this(httpVersion, method, uri, clientIp, userAgent, referer);
+    this(httpVersion, method, uri, clientIp, userAgent, referer, zipkinParentId, zipkinTraceId);
     this.response = new ResponseBag(statusCode, responseSize);
     this.timeTaken = timeTaken;
   }
@@ -85,6 +91,14 @@ public class AccessLog {
     return this.response.responseSize;
   }
 
+  public String zipkinParentId() {
+    return this.traceBag.getxParentId();
+  }
+
+  public String zipkinTraceId() {
+    return this.traceBag.getxTraceId();
+  }
+
   public String format(AccessLogFormatter logFormatter) {
     return logFormatter.format(this);
   }
@@ -122,6 +136,24 @@ public class AccessLog {
       this.ip = clientIp;
       this.userAgent = userAgent;
       this.referer = referer;
+    }
+  }
+
+  private class TraceBag {
+    private String zipkinParentId;
+    private String zipkinTraceId;
+
+    public TraceBag(String zipkinParentId, String zipkinTraceId) {
+      this.zipkinParentId = zipkinParentId;
+      this.zipkinTraceId = zipkinTraceId;
+    }
+
+    public String getxParentId() {
+      return zipkinParentId;
+    }
+
+    public String getxTraceId() {
+      return zipkinTraceId;
     }
   }
 }

--- a/src/main/java/com/scmspain/karyon/accesslog/formatters/CommonApacheLog.java
+++ b/src/main/java/com/scmspain/karyon/accesslog/formatters/CommonApacheLog.java
@@ -16,7 +16,7 @@ public class CommonApacheLog implements AccessLogFormatter{
       logLine.uri(),
       logLine.httpVersion(),
       logLine.statusCode(),
-      (long) 0
+      logLine.responseSize()
     );
   }
 }

--- a/src/main/java/com/scmspain/karyon/accesslog/formatters/SchibstedApacheLog.java
+++ b/src/main/java/com/scmspain/karyon/accesslog/formatters/SchibstedApacheLog.java
@@ -3,6 +3,8 @@ package com.scmspain.karyon.accesslog.formatters;
 import com.google.inject.Inject;
 import com.scmspain.karyon.accesslog.AccessLog;
 
+import java.lang.ref.ReferenceQueue;
+
 public class SchibstedApacheLog implements AccessLogFormatter {
 
   private CombinedApacheLog combinedApacheLogFormatter;
@@ -14,11 +16,15 @@ public class SchibstedApacheLog implements AccessLogFormatter {
 
   @Override
   public String format(AccessLog logLine) {
+
+
+
     return String.format(
-      "%s %d %d",
+      "%s %d \"%s\" \"%s\"",
       combinedApacheLogFormatter.format(logLine),
-      logLine.responseSize(),
-      logLine.timeTaken()
+      logLine.timeTaken(),
+      logLine.zipkinParentId(),
+      logLine.zipkinTraceId()
     );
   }
 

--- a/src/main/java/com/scmspain/karyon/accesslog/formatters/SchibstedApacheLog.java
+++ b/src/main/java/com/scmspain/karyon/accesslog/formatters/SchibstedApacheLog.java
@@ -23,9 +23,13 @@ public class SchibstedApacheLog implements AccessLogFormatter {
       "%s %d \"%s\" \"%s\"",
       combinedApacheLogFormatter.format(logLine),
       logLine.timeTaken(),
-      logLine.zipkinParentId(),
-      logLine.zipkinTraceId()
+      valueOrDefault(logLine.zipkinParentId()),
+      valueOrDefault(logLine.zipkinTraceId())
     );
+  }
+
+  private String valueOrDefault(String value) {
+    return (null != value && !value.isEmpty()) ? value : "-";
   }
 
 }

--- a/src/test/java/com/scmspain/karyon/accesslog/AccessLogTest.java
+++ b/src/test/java/com/scmspain/karyon/accesslog/AccessLogTest.java
@@ -4,6 +4,8 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import org.junit.Test;
 
+import java.util.UUID;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -20,6 +22,9 @@ public class AccessLogTest {
   private Long timeTaken;
   private Long responseSize;
 
+  private String zipkinParentId;
+  private String zipkinTraceId;
+
   private AccessLog log;
 
   @Test
@@ -34,6 +39,7 @@ public class AccessLogTest {
     givenARequestWithUserInformation();
     whenAccessLogIsCreatedWithUserInfo();
     thenLogShouldContainUserInformation();
+    thenShouldContainTraceInformation();
   }
 
   @Test
@@ -44,6 +50,7 @@ public class AccessLogTest {
     responseSize = (long) 123456;
     whenAccessLogIsCreatedWithResponseInfo();
     thenLogShouldContainResponseInformation();
+    thenShouldContainTraceInformation();
   }
 
   @Test
@@ -66,10 +73,13 @@ public class AccessLogTest {
     thenLogShouldContainResponseInformation();
   }
 
+
   private void givenARequest() {
     httpVersion = HttpVersion.HTTP_1_0.toString();
     method = HttpMethod.GET.toString();
     uri = "/status";
+    zipkinParentId = UUID.randomUUID().toString();
+    zipkinTraceId = UUID.randomUUID().toString();
   }
 
   private void givenARequestWithUserInformation() {
@@ -84,7 +94,8 @@ public class AccessLogTest {
   }
 
   private void whenAccessLogIsCreatedWithUserInfo() {
-    log = new AccessLog(httpVersion, method, uri, clientIp, userAgent, referer);
+    log = new AccessLog(httpVersion, method, uri, clientIp, userAgent, referer,
+        zipkinParentId, zipkinTraceId);
   }
 
   private void whenAccessLogIsCreatedWithResponseInfo() {
@@ -97,7 +108,9 @@ public class AccessLogTest {
         referer,
         statusCode,
         timeTaken,
-        responseSize
+        responseSize,
+        zipkinParentId,
+        zipkinTraceId
     );
   }
 
@@ -117,5 +130,10 @@ public class AccessLogTest {
     assertThat(log.statusCode(), is(statusCode));
     assertThat(log.timeTaken(), is(timeTaken));
     assertThat(log.responseSize(), is(responseSize));
+  }
+
+  private void thenShouldContainTraceInformation() {
+    assertThat(log.zipkinParentId(), is(zipkinParentId));
+    assertThat(log.zipkinTraceId(), is(zipkinTraceId));
   }
 }


### PR DESCRIPTION
Modify access log, correcting response size element (was duplicated) and adding Zipkin trace information.

- Removed log4j library should fix #21 

@padilo @fiunchinho @aramirez-es @victuxbb Can you take a look please? 